### PR TITLE
uno.go unit tests

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10761,15 +10761,9 @@
       }
     },
     "websocket-extensions": {
-<<<<<<< Updated upstream
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
-=======
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
->>>>>>> Stashed changes
     },
     "which": {
       "version": "1.3.1",

--- a/server/uno.go
+++ b/server/uno.go
@@ -67,8 +67,8 @@ var gameStarted bool = false
 ////////////////////////////////////////////////////////////
 // Utility functions
 ////////////////////////////////////////////////////////////
-func newRandomCard() []Card {
-	return []Card{Card{rand.Intn(10), randColor(rand.Intn(4))}}
+func newRandomCard() Card {
+	return Card{rand.Intn(10), randColor(rand.Intn(4))}
 }
 
 func newPayload(user string) map[string]interface{} { // User will default to "" if not passed
@@ -181,7 +181,7 @@ func drawCard(c echo.Context) *Response {
 	if checkID(c.Param("game")) && c.Param("username") == currPlayer {
 		playerIndex = (playerIndex + 1) % len(players)
 		currPlayer = players[playerIndex]
-		allCards[c.Param("username")] = append(allCards[c.Param("username")], newRandomCard()[0])
+		allCards[c.Param("username")] = append(allCards[c.Param("username")], newRandomCard())
 		return &Response{true, newPayload(c.Param("username"))}
 	}
 	return &Response{false, nil}
@@ -197,12 +197,12 @@ func dealCards() {
 	for k := range players {
 		cards := []Card{}
 		for i := 0; i < 7; i++ {
-			cards = append(cards, Card{rand.Intn(10), randColor(rand.Intn(4))})
+			cards = append(cards, newRandomCard())
 		}
 		allCards[players[k]] = cards
 	}
 
-	currCard = newRandomCard()
+	currCard = []Card{newRandomCard()}
 }
 
 // TODO: make sure this reflects on the front end

--- a/server/uno_test.go
+++ b/server/uno_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRandColor(t *testing.T) {
+	// test that the colors work
+	assert.Equal(t, "red", randColor(0))
+	assert.Equal(t, "blue", randColor(1))
+	assert.Equal(t, "green", randColor(2))
+	assert.Equal(t, "yellow", randColor(3))
+
+	// test that other input produces an empty string
+	assert.Equal(t, "", randColor(-1))
+	assert.Equal(t, "", randColor(4))
+}
+
+func TestNewRandomCard(t *testing.T) {
+	// Try 1000 times
+	for i := 0; i < 1000; i++ {
+		card := newRandomCard()
+		// a valid number should always be produced
+		// if our usage of rand.Intn is correct
+		assert.Less(t, -1, card.Number)
+		assert.Greater(t, 10, card.Number)
+
+		// An actual color should always be produced
+		assert.NotEqual(t, "", card.Color)
+	}
+}
+
+func TestCheckID(t *testing.T) {
+	// Do not rely on the bug in uno.go that always sets the gameID to 12234
+	gameID = "testingid"
+	assert.Equal(t, true, checkID("testingid"))
+	assert.Equal(t, false, checkID("wrongid"))
+}
+
+func TestContains(t *testing.T) {
+	usernames := []string{"pippin", "merry", "eowyn", "faramir"}
+
+	// test that it finds an element
+	index, found := contains(usernames, "eowyn")
+	assert.Equal(t, 2, index)
+	assert.Equal(t, true, found)
+
+	// test that it does not find something that is not an element
+	index, found = contains(usernames, "boromir")
+	assert.Equal(t, -1, index)
+	assert.Equal(t, false, found)
+}


### PR DESCRIPTION
This PR contains 3 commits:
- Remove merge conflict markers from `package-lock.json`. Not sure why those were pushed to `dev`.
- Change `newRandomCard()` to return a card instead of an array because logically, it should give you a card, not a single element array. Just seemed unnecessary to always access the new random card with `[0]`
- And finally, unit tests for `uno.go` that bring code coverage up to 34.1%.