### PR TITLE
Changing the coverage action be based on jak103/dev branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,9 @@ on:
       - dev
       - development
   pull_request:
-    branches: [ master ]
+    branches:
+      - dev
+      - master
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -6,7 +6,9 @@ name: Coverage
 # events but only for the master branch
 on:
   push:
-    branches: [ development ]
+    branches:
+      - dev
+      - development
   pull_request:
     branches: [ master ]
 
@@ -33,4 +35,4 @@ jobs:
       uses: shogo82148/actions-goveralls@v1.4.0
       with:
         path-to-profile: server-coverage.cov
-        working-directory: server 
+        working-directory: server

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,7 +14,7 @@ on:
       - dev
       - master
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel 
 jobs:
   # This workflow contains a single job called "build"
   build:

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ![Go](https://github.com/jak103/uno/workflows/Go/badge.svg?branch=master)
-
 ![Docker Image CI](https://github.com/jak103/uno/workflows/Docker%20Image%20CI/badge.svg)
-
-[![Coverage Status](https://coveralls.io/repos/github/brent-buffenbarger/uno/badge.svg?branch=development)](https://coveralls.io/github/brent-buffenbarger/uno)
+[![Coverage Status](https://coveralls.io/repos/github/jak103/uno/badge.svg?branch=dev)](https://coveralls.io/github/jak103/uno)
 
 Read me
 


### PR DESCRIPTION
Submitting pull request to make the coverage action report on the jak103/dev branch. I am not sure this is going to work and need it to be pulled in to to test it.

There are some limitations to this action that I have not been able to fix. The first limitation is that the coverage will only work on the branch specified in the README.md, so it will always be reporting the coverage for the jak103/dev branch, I believe. The second limitation is that this is only reporting test coverage from the server working-directory. We could put in a second action to report coverage for the other working directories, but I am not sure how to combine them all into one single report.