### PR TITLE
I believe this resolves the model and db paths

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -1,4 +1,4 @@
-module github.com/jak103/uno
+module github.com/jak103/uno/server
 
 go 1.14
 


### PR DESCRIPTION
This message appears during failed tests. 

 github.com/jak103/usu-uno/server.test imports
 github.com/jak103/uno/server/model: github.com/jak103/uno/server@v0.0.0-20200724022813-5b52af632fd9: parsing go.mod:
 module declares its path as: github.com/jak103/uno
         but was required as: github.com/jak103/uno/server