### PR TITLE
Fix crash on mongo start.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - MONGO_INITDB_ROOT_PASSWORD=uno
     volumes:
       - mongo-volume:/data/db
-      - ./db/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
     ports:
       - '27017-27019:27017-27019'
     #   db:


### PR DESCRIPTION
This removes a mount that was left in from the original implementation of mongo, and should fix the crash on startup.