### PR TITLE
Change wildcard color to black for frontend rendering

### DIFF
--- a/server/deckUtils.go
+++ b/server/deckUtils.go
@@ -78,7 +78,7 @@ func generateShuffledDeck() []model.Card {
 
 	for cardValue, count := range wildCardCounts {
 		for i := 0; i < count; i++ {
-			deck = append(deck, model.Card{"wild", cardValue})
+			deck = append(deck, model.Card{"black", cardValue})
 		}
 	}
 

--- a/server/deckUtils_test.go
+++ b/server/deckUtils_test.go
@@ -22,7 +22,7 @@ func TestGenerateShuffledDeck(t *testing.T) {
 		"blue": 0,
 		"green": 0,
 		"yellow": 0,
-		"wild": 0,
+		"black": 0,
 	}
 
 	for _, card := range deck {
@@ -33,7 +33,7 @@ func TestGenerateShuffledDeck(t *testing.T) {
 	assert.Equal(t, 25, colorCounts["blue"])
 	assert.Equal(t, 25, colorCounts["green"])
 	assert.Equal(t, 25, colorCounts["yellow"])
-	assert.Equal(t, 8, colorCounts["wild"])
+	assert.Equal(t, 8, colorCounts["black"])
 
 	//Check that the deck has the right number of total cards
 	assert.Equal(t, 108, len(deck))


### PR DESCRIPTION
The server now sets the wildcard color to "black" so that the frontend renders the background of the card as black. Requested by @stuhops 