### PR TITLE
Db interface create game updates

### DIFF
--- a/server/db/FirestoreDB.go
+++ b/server/db/FirestoreDB.go
@@ -53,15 +53,26 @@ func (db *firestoreDB) HasGameByID(id string) bool {
 }
 
 // CreateGame a game with the given ID. Perhaps this should instead just return an id?
-func (db *firestoreDB) CreateGame() (*model.Game, error) {
-	game := model.Game{ID: uuid.New().String(), Password: "12234"}
-	gameDoc := db.games.Doc(game.ID)
-
-	if _, err := gameDoc.Create(context.Background(), game); err != nil {
+func (db *firestoreDB) CreateGame(gameName string, creatorID string) (*model.Game, error) {
+	player, err := db.LookupPlayer(creatorID)
+	if err != nil {
 		return nil, err
 	}
 
-	return &game, nil
+	myGame := model.Game{
+		ID:       uuid.New().String(),
+		Password: "12234",
+		Creator:  *player,
+		Name:     gameName,
+		Status:   model.WaitingForPlayers}
+	myGame.Players = append(myGame.Players, *player)
+	gameDoc := db.games.Doc(myGame.ID)
+
+	if _, err := gameDoc.Create(context.Background(), myGame); err != nil {
+		return nil, err
+	}
+
+	return &myGame, nil
 }
 
 // CreatePlayer creates the player in the database

--- a/server/db/MockDB.go
+++ b/server/db/MockDB.go
@@ -37,10 +37,18 @@ func (db *mockDB) HasGameByID(id string) bool {
 }
 
 // CreateGame a game with the given ID. Perhaps this should instead just return an id?
-func (db *mockDB) CreateGame() (*model.Game, error) {
-	myGame := model.Game{ID: uuid.New().String(), Password: "12234"}
+func (db *mockDB) CreateGame(gameName string, creatorID string) (*model.Game, error) {
+	player, _ := db.LookupPlayer(creatorID)
+	myGame := model.Game{
+		ID:       uuid.New().String(),
+		Password: "12234",
+		Creator:  *player,
+		Name:     gameName,
+		Status:   model.WaitingForPlayers}
 	db.games[myGame.ID] = myGame
 	db.gamePasswords[myGame.Password] = myGame
+
+	db.JoinGame(myGame.ID, player.ID)
 	return &myGame, nil
 }
 

--- a/server/db/MongoDB.go
+++ b/server/db/MongoDB.go
@@ -54,13 +54,25 @@ func (db *mongoDB) HasGameByID(id string) bool {
 }
 
 // CreateGame a game with the given ID. Perhaps this should instead just return an id?
-func (db *mongoDB) CreateGame() (*model.Game, error) {
-	myGame := model.Game{Password: ""}
+func (db *mongoDB) CreateGame(gameName string, creatorID string) (*model.Game, error) {
+	player, err := db.LookupPlayer(creatorID)
+	if err != nil {
+		return nil, err
+	}
+
+	myGame := model.Game{
+		Password: "12234",
+		Creator:  *player,
+		Name:     gameName,
+		Status:   model.WaitingForPlayers}
+	myGame.Players = append(myGame.Players, *player)
+
 	res, err := db.games.InsertOne(context.Background(), myGame)
 	if err != nil {
 		return nil, err
 	}
 	myGame.ID = res.InsertedID.(primitive.ObjectID).Hex()
+
 	return &myGame, nil
 }
 

--- a/server/db/UnoDB.go
+++ b/server/db/UnoDB.go
@@ -13,7 +13,7 @@ type UnoDB interface {
 	// Check if a game with the given ID exists in the database.
 	HasGameByID(game string) bool
 	// Creates a game.
-	CreateGame() (*model.Game, error)
+	CreateGame(gameName string, creatorID string) (*model.Game, error)
 	// Creates a player with the given name.
 	CreatePlayer(name string) (*model.Player, error)
 	// DeleteGame deletes a game

--- a/server/uno.go
+++ b/server/uno.go
@@ -74,24 +74,19 @@ func createPlayer(name string) (*model.Player, error) {
 
 func createNewGame(gameName string, creatorName string) (*model.Game, *model.Player, error) {
 	database, err := db.GetDb()
-	game, err := database.CreateGame()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	creator, e := createPlayer(creatorName)
-
-	if e != nil {
-		return nil, nil, e
-	}
-
-	game, err = database.JoinGame(game.ID, creator.ID)
+	creator, err := database.CreatePlayer(creatorName)
 	if err != nil {
 		return nil, nil, err
 	}
-	game.Name = gameName
-	game.Creator = *creator
-	game.Status = model.WaitingForPlayers
+
+	game, err := database.CreateGame(gameName, creator.ID)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	err = database.SaveGame(*game)
 	if err != nil {


### PR DESCRIPTION
This cleans up the CreateGame interface for the database. Creating a game now requires a game name and an ID for the game creator. 

The PR updates the interface, mock, mongo, firestore, and Vue client to handle the updated interface.

There should be no visible difference when playing the game. 