### PR TITLE
Num cards in deck

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -50,7 +50,6 @@
           <v-col cols="12" v-if="gameState.status === 'Playing'">
             <v-row v-if="gameState.current_card != undefined">
               <v-card class="center-text ma-3 pa-6" outlined tile>
-              <center>Current Card</center>
                 <Card
                   :number="gameState.current_card.value"
                   :key="gameState.current_card.color"

--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -10,7 +10,7 @@
             <v-card class="ma-3 pa-6" outlined tile>
               Current Game id: {{ gameState.game_id }}
               <br />
-              Status: {{gameState.status}}      
+              Status: {{gameState.status}}
             </v-card>
           </v-row>
 
@@ -31,6 +31,7 @@
           <v-col cols="12" v-if="gameState.status === 'Playing'">
             <v-row v-if="gameState.current_card != undefined">
               <v-card class="center-text ma-3 pa-6" outlined tile>
+              <center>Current Card</center>
                 <Card
                   :number="gameState.current_card.value"
                   :key="gameState.current_card.color"


### PR DESCRIPTION
Adding another line to the game stats section to display how many cards are remaining in the draw pile. I was unsure where this number should be displayed, but I figured the game stats section was the most appropriate. I have no preference as to where it is displayed if someone thinks it should be elsewhere on the screen.

![Cards remaining in draw pile](https://user-images.githubusercontent.com/59784636/89132755-a9ca0b00-d4d3-11ea-89b2-915227361dd4.PNG)

