### PR TITLE
Fix typo in wildcard color chooser

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -192,7 +192,7 @@
         <v-card-title
           class="blue"
         >
-          Chose color for Wild card
+          Choose a wildcard color
         </v-card-title>
         <v-card-actions>
             <v-col>


### PR DESCRIPTION
Fixing a simple typo