### PR TITLE
formatting problem

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -147,9 +147,9 @@
 
               <v-row v-else class="pl-3">
                 Organize Cards
-                <v-btn @click.native="orgByColor">by Color</v-btn>
-                <v-btn @click.native="orgByNum">by Number</v-btn>
-                <v-btn @click.native="orgOff">Off</v-btn>
+                <v-btn class="org-btn" @click.native="orgByColor">by Color</v-btn>
+                <v-btn class="org-btn" @click.native="orgByNum">by Number</v-btn>
+                <v-btn class="org-btn" @click.native="orgOff">Off</v-btn>
               </v-row>
             </v-card>
 
@@ -491,6 +491,9 @@ export default {
     min-width: 160px;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     z-index: 1;
+  }
+  .org-btn {
+    margin: 10px;
   }
   /* Show the dropdown menu on hover */
   .dropdown:hover .dropdown_content, .hintbtn a:hover {display: block;}


### PR DESCRIPTION
Added margin to the organize cards area so the buttons don't pack so close together after wrapping on narrow windows.
![before](https://user-images.githubusercontent.com/22205943/89361437-84cac900-d688-11ea-8e8b-5326591390bb.png)
![after](https://user-images.githubusercontent.com/22205943/89361438-85635f80-d688-11ea-90d4-0e3fe8e625af.png)

