### PR TITLE
Color Contrast Accessibility Requirement

### DIFF
--- a/client/src/views/Lobby.vue
+++ b/client/src/views/Lobby.vue
@@ -11,7 +11,7 @@
           width="1000"              
         >
           <v-card-title 
-            style="background-color: #33B0FF"                                 
+            style="background-color: #007BC7"                                 
           >
             Games  
             <v-spacer></v-spacer>


### PR DESCRIPTION
Accessibility requirement says that our color contrast with the blue and white needs to change. 

Color contrast (1.4.3): There must be a color contrast ratio of at least 4.5:1 between all text and background. 
Our current blue: #33b0ff 
This blue satisfies the requirement: #007BC7