### PR TITLE
Allow a playable card to be played after being drawn

### DIFF
--- a/server/uno.go
+++ b/server/uno.go
@@ -195,7 +195,10 @@ func drawCard(gameID string, playerID string) (*model.Game, error) {
 		// append the card into the players cards from the draw pile
 		player.Cards = append(player.Cards, drawnCard)
 
-		gameData = goToNextPlayer(gameData)
+		// if the card cannot be played, advance to the next player
+		if !isCardPlayable(drawnCard, gameData.DiscardPile) {
+			gameData = goToNextPlayer(gameData)
+		}
 
 		// Save the game into the database
 		database.SaveGame(*gameData)

--- a/server/uno.go
+++ b/server/uno.go
@@ -116,7 +116,7 @@ func playCard(game string, playerID string, card model.Card) (*model.Game, error
 
 	if gameData.Players[gameData.CurrentPlayer].ID == playerID {
 		hand := gameData.Players[gameData.CurrentPlayer].Cards
-		if checkForCardInHand(card, hand) && (card.Color == gameData.DiscardPile[len(gameData.DiscardPile)-1].Color || card.Value == gameData.DiscardPile[len(gameData.DiscardPile)-1].Value || card.Value == "W4" || card.Value == "W") {
+		if checkForCardInHand(card, hand) && isCardPlayable(card, gameData.DiscardPile) {
 			// Valid card can be played
 
 			gameData.DiscardPile = append(gameData.DiscardPile, card)
@@ -274,6 +274,22 @@ func dealCards(game *model.Game) (*model.Game, error) {
 ////////////////////////////////////////////////////////////
 // Utility Functions
 ////////////////////////////////////////////////////////////
+
+// Checks if a card is playable
+// Card is playable if it is wild or matches the card on top of the discard pile
+// Does not check that the card is in the player's hand
+// Use checkForCardInHand for that
+func isCardPlayable(card model.Card, discardPile []model.Card) bool {
+	isWild := card.Value == "W4" || card.Value == "W"
+
+	cardOnDiscardPile := discardPile[len(discardPile)-1]
+
+	if (card.Color == cardOnDiscardPile.Color || card.Value == cardOnDiscardPile.Value || isWild) {
+		return true
+	}
+
+	return false
+}
 
 func checkForCardInHand(card model.Card, hand []model.Card) bool {
 	for _, c := range hand {

--- a/server/uno_test.go
+++ b/server/uno_test.go
@@ -34,6 +34,11 @@ func TestDrawCard(t *testing.T) {
 	// Generate real game in database and real player
 	database, _ := db.GetDb()
 	game, player := setupGameWithPlayer(database)
+	
+	// Put a number card on the discard pile
+	// For the purposes of this test, it's ok that it's an extra card
+	game.DiscardPile = append(game.DiscardPile, model.Card{"red", "2"})
+	database.SaveGame(*game)
 
 	// Test Drawing a card with a full deck and real player
 	game, err = drawCard(game.ID, player.ID)

--- a/server/uno_test.go
+++ b/server/uno_test.go
@@ -68,7 +68,7 @@ func TestDrawCard(t *testing.T) {
 	// Assert last card in discard is actually to proper last card
 	assert.Nil(t, err, "Failed to draw card.")
 	assert.Equal(t, 2, len(player.Cards))
-	assert.Equal(t, 105, len(game.DrawPile))
+	assert.Equal(t, 106, len(game.DrawPile))
 	assert.Equal(t, 1, len(game.DiscardPile))
 	assert.Equal(t, lastCard.Color, game.DiscardPile[0].Color)
 	assert.Equal(t, lastCard.Value, game.DiscardPile[0].Value)


### PR DESCRIPTION
I'm making another issue for someone to implement not having to play a playable card that is drawn.

The drawCard test was drawing a card with an empty discard pile, and now that drawCard checks if a card is playable, the test has to have a number card on the drawpile to start. So, I hard coded that in, and adjusted an expected value for the draw pile after the discard has been reshuffled.