### PR TITLE
Snackbar player colors

### DIFF
--- a/client/src/components/Chat.vue
+++ b/client/src/components/Chat.vue
@@ -97,7 +97,7 @@ export default {
                     // If we have a new message scroll down and tell the game
                     if ( len__new !== len__old ) {
                         this.loop_scroll = true;
-                        this.$emit('snackbarText', this.messages[len__new].player.name, this.messages[len__new].message)
+                        this.$emit('snackbarText', this.messages[len__new].player.name, this.messages[len__new].message, this.messages[len__new].player.color)
                     }
                 }
                 this.info = null;

--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -230,10 +230,11 @@
 
       <v-snackbar
         v-model="snackbar"
-        color="info"
+        :color="playerColor"
         :timeout='4000'
         v-show="gameState.status === 'Playing' && playerName !== newMessageName"
-        >{{snackbarText}}
+      >
+          {{snackbarText}}
         <v-btn text @click="snackbar=false">
           Close
         </v-btn>

--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -284,6 +284,7 @@ export default {
       snackbar: false,
       snackbarText: "",
       newMessageName: "",
+      playerColor: "",
     };
   },
 
@@ -338,9 +339,10 @@ export default {
       this.sortByColor = true;
     },
 
-    runsnackbar(name, message) {
+    runsnackbar(name, message, color) {
       this.newMessageName = name;
       this.snackbarText = name + " says: " + message;
+      this.playerColor = color;
       this.snackbar = true;
     },
 


### PR DESCRIPTION
The snackbar popup for new messages now displays with the user's assigned color.


<img width="1680" alt="Screen Shot 2020-08-04 at 8 58 50 PM" src="https://user-images.githubusercontent.com/24553606/89367225-b72ef300-d695-11ea-9a5f-fbc0702c5146.png">
<img width="1680" alt="Screen Shot 2020-08-04 at 8 59 07 PM" src="https://user-images.githubusercontent.com/24553606/89367236-bb5b1080-d695-11ea-90bb-73e07ce445c7.png">
